### PR TITLE
New Summoner not found component

### DIFF
--- a/src/main/java/com/safjnest/core/events/EventAutoCompleteInteractionHandler.java
+++ b/src/main/java/com/safjnest/core/events/EventAutoCompleteInteractionHandler.java
@@ -31,7 +31,6 @@ import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.Command.Choice;
 import no.stelar7.api.r4j.basic.constants.api.regions.LeagueShard;
-import no.stelar7.api.r4j.impl.R4J;
 import no.stelar7.api.r4j.pojo.lol.staticdata.item.Item;
 import no.stelar7.api.r4j.pojo.lol.summoner.Summoner;
 import no.stelar7.api.r4j.pojo.shared.RiotAccount;


### PR DESCRIPTION
When you /summoner profile sunxy#0117, instead of a useless "summoner not found message" could be nice

a new components like:
Summoner not found
Here some suggestions:
maybe with a menu, or components v2

do some tests